### PR TITLE
Add React project with Movement Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# formula-d-utils
+# Formula D Utils
+
+Herramienta web modular para apoyar partidas de Formula D.
+
+## Desarrollo
+
+Proyecto creado con Vite + React + TypeScript. Usa TailwindCSS para estilos.
+
+Las herramientas se encuentran en `src/components/tools/`.
+
+### Scripts
+
+- `npm run dev` – inicia la aplicación en desarrollo
+- `npm run build` – genera la versión de producción
+
+Algunas dependencias pueden requerir instalación previa con `npm install`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Formula D Utils</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "formula-d-utils",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,12 @@
+import MovementCalculator from './components/tools/MovementCalculator/MovementCalculator';
+
+function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Formula D Utils</h1>
+      <MovementCalculator />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/tools/MovementCalculator/MovementCalculator.tsx
+++ b/src/components/tools/MovementCalculator/MovementCalculator.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import {
+  getGearRange,
+  probabilityToReach,
+  suggestGear,
+} from '../../../utils/formulaD';
+
+function MovementCalculator() {
+  const [gear, setGear] = useState(1);
+  const [distance, setDistance] = useState(1);
+
+  const range = getGearRange(gear);
+  const prob = probabilityToReach(gear, distance);
+  const suggestion = suggestGear(distance);
+
+  return (
+    <div className="border p-4 rounded shadow max-w-md">
+      <h2 className="text-xl font-semibold mb-2">Calculadora de Movimiento</h2>
+      <div className="flex flex-col gap-2">
+        <label>
+          Marcha:
+          <select
+            className="ml-2 border p-1"
+            value={gear}
+            onChange={(e) => setGear(Number(e.target.value))}
+          >
+            {[1, 2, 3, 4, 5, 6].map((g) => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Casillas hasta curva:
+          <input
+            type="number"
+            className="ml-2 border p-1 w-20"
+            value={distance}
+            min={1}
+            onChange={(e) => setDistance(Number(e.target.value))}
+          />
+        </label>
+      </div>
+      <div className="mt-4">
+        <p>
+          Rango de tirada para marcha {gear}: {range.min}-{range.max}
+        </p>
+        <p>
+          Prob. de quedarse corto: {(prob.under * 100).toFixed(0)}%
+        </p>
+        <p>Prob. de exacto: {(prob.exact * 100).toFixed(0)}%</p>
+        <p>Prob. de pasarse: {(prob.over * 100).toFixed(0)}%</p>
+        <p className="mt-2 font-semibold">
+          Marcha sugerida: {suggestion}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default MovementCalculator;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/utils/formulaD.ts
+++ b/src/utils/formulaD.ts
@@ -1,0 +1,40 @@
+export interface GearInfo {
+  min: number;
+  max: number;
+  dice: number[];
+}
+
+export const gears: Record<number, GearInfo> = {
+  1: { min: 1, max: 2, dice: [1, 2] },
+  2: { min: 2, max: 4, dice: [2, 3, 4] },
+  3: { min: 4, max: 8, dice: [4, 5, 6, 7, 8] },
+  4: { min: 7, max: 12, dice: [7, 8, 9, 10, 11, 12] },
+  5: { min: 11, max: 20, dice: [11,12,13,14,15,16,17,18,19,20] },
+  6: { min: 21, max: 30, dice: [21,22,23,24,25,26,27,28,29,30] },
+};
+
+export function getGearRange(gear: number) {
+  return gears[gear];
+}
+
+export function probabilityToReach(gear: number, distance: number) {
+  const { dice } = gears[gear];
+  const total = dice.length;
+  const under = dice.filter((d) => d < distance).length / total;
+  const exact = dice.filter((d) => d === distance).length / total;
+  const over = dice.filter((d) => d > distance).length / total;
+  return { under, exact, over };
+}
+
+export function suggestGear(distance: number) {
+  let best = 1;
+  let minOver = Infinity;
+  for (const g of Object.keys(gears).map(Number)) {
+    const { max } = gears[g];
+    if (max >= distance && max < minOver) {
+      best = g;
+      minOver = max;
+    }
+  }
+  return best;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite React app with TypeScript and TailwindCSS
- add utils for Formula D dice ranges and suggestions
- implement Movement Calculator tool
- document development instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c19de01d8832ca482022cc814a176