### PR TITLE
Add responsive layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Formula D Utils</title>
   </head>
-  <body>
+  <body class="font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import Layout, { ToolId } from './components/layout/Layout';
 import MovementCalculator from './components/tools/MovementCalculator/MovementCalculator';
 import DiceRoller from './components/tools/DiceRoller/DiceRoller';
 import DamagePanel from './components/tools/DamagePanel/DamagePanel';
@@ -5,15 +7,31 @@ import CurveAssistant from './components/tools/CurveAssistant/CurveAssistant';
 import GameLog from './components/tools/GameLog/GameLog';
 
 function App() {
+  const [tool, setTool] = useState<ToolId>('movement');
+
+  let content: JSX.Element;
+  switch (tool) {
+    case 'dice':
+      content = <DiceRoller />;
+      break;
+    case 'damage':
+      content = <DamagePanel />;
+      break;
+    case 'curve':
+      content = <CurveAssistant />;
+      break;
+    case 'log':
+      content = <GameLog />;
+      break;
+    case 'movement':
+    default:
+      content = <MovementCalculator />;
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Formula D Utils</h1>
-      <MovementCalculator />
-      <DiceRoller />
-      <DamagePanel />
-      <CurveAssistant />
-      <GameLog />
-    </div>
+    <Layout current={tool} setCurrent={setTool}>
+      {content}
+    </Layout>
   );
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,41 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export interface NavItem {
+  id: string;
+  label: string;
+}
+
+interface HeaderProps {
+  nav: NavItem[];
+  current: string;
+  onSelect: Dispatch<SetStateAction<string>> | ((id: string) => void);
+  onMenu: () => void;
+}
+
+function Header({ nav, current, onSelect, onMenu }: HeaderProps) {
+  return (
+    <header className="bg-gray-800 text-white px-4 py-3 flex items-center justify-between">
+      <h1 className="text-lg font-semibold">Formula D Utils</h1>
+      <nav className="hidden md:flex gap-4">
+        {nav.map((item) => (
+          <button
+            key={item.id}
+            className={`pb-1 border-b-2 ${
+              current === item.id ? 'border-white' : 'border-transparent'
+            }`}
+            onClick={() => onSelect(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
+      <button className="md:hidden" onClick={onMenu} aria-label="Menu">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,57 @@
+import { ReactNode, useState } from 'react';
+import Header, { NavItem } from './Header';
+import Sidebar from './Sidebar';
+
+export type ToolId = 'movement' | 'dice' | 'damage' | 'curve' | 'log';
+
+interface LayoutProps {
+  children: ReactNode;
+  current: ToolId;
+  setCurrent: (id: ToolId) => void;
+}
+
+const navItems: NavItem[] = [
+  { id: 'movement', label: 'Movimiento' },
+  { id: 'dice', label: 'Tiradas' },
+  { id: 'damage', label: 'Daños' },
+  { id: 'curve', label: 'Curvas' },
+  { id: 'log', label: 'Registro' },
+];
+
+function Layout({ children, current, setCurrent }: LayoutProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen flex flex-col font-sans text-gray-800">
+      <Header
+        nav={navItems}
+        current={current}
+        onSelect={(id) => setCurrent(id as ToolId)}
+        onMenu={() => setMobileOpen(true)}
+      />
+      <div className="flex flex-1">
+        <Sidebar
+          nav={navItems}
+          current={current}
+          onSelect={(id) => setCurrent(id as ToolId)}
+          className="hidden md:block"
+        />
+        <main className="flex-1 p-4 max-w-screen-md w-full mx-auto">{children}</main>
+      </div>
+      <Sidebar
+        nav={navItems}
+        current={current}
+        onSelect={(id) => {
+          setCurrent(id as ToolId);
+          setMobileOpen(false);
+        }}
+        mobile
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        className="md:hidden"
+      />
+    </div>
+  );
+}
+
+export default Layout;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,47 @@
+import { Dispatch, SetStateAction } from 'react';
+import type { NavItem } from './Header';
+
+interface SidebarProps {
+  nav: NavItem[];
+  current: string;
+  onSelect: Dispatch<SetStateAction<string>> | ((id: string) => void);
+  open?: boolean;
+  onClose?: () => void;
+  mobile?: boolean;
+  className?: string;
+}
+
+function Sidebar({ nav, current, onSelect, open = false, onClose, mobile = false, className = '' }: SidebarProps) {
+  const base = mobile
+    ? `fixed inset-y-0 left-0 w-64 bg-white shadow transform transition-transform z-20 ${open ? 'translate-x-0' : '-translate-x-full'}`
+    : `w-48 bg-gray-100 p-4 ${className}`;
+
+  const content = (
+    <div className="h-full flex flex-col gap-2 p-4">
+      {nav.map((item) => (
+        <button
+          key={item.id}
+          className={`text-left ${current === item.id ? 'font-semibold' : ''}`}
+          onClick={() => onSelect(item.id)}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+
+  if (mobile) {
+    return (
+      <div className={base}>
+        <button className="absolute top-2 right-2" onClick={onClose} aria-label="Cerrar">
+          ✕
+        </button>
+        {content}
+      </div>
+    );
+  }
+
+  return <aside className={base}>{content}</aside>;
+}
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- implement responsive header and sidebar
- provide layout component to center content and handle navigation
- update `App.tsx` to use new layout
- set base font family in `index.html`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1e6744a0832c961999693dca0e23