### PR TITLE
Improve MovementCalculator responsive design

### DIFF
--- a/src/components/tools/MovementCalculator/MovementCalculator.tsx
+++ b/src/components/tools/MovementCalculator/MovementCalculator.tsx
@@ -14,46 +14,52 @@ function MovementCalculator() {
   const suggestion = suggestGear(distance);
 
   return (
-    <div className="border p-4 rounded shadow max-w-md">
-      <h2 className="text-xl font-semibold mb-2">Calculadora de Movimiento</h2>
-      <div className="flex flex-col gap-2">
-        <label>
-          Marcha:
-          <select
-            className="ml-2 border p-1"
-            value={gear}
-            onChange={(e) => setGear(Number(e.target.value))}
-          >
-            {[1, 2, 3, 4, 5, 6].map((g) => (
-              <option key={g} value={g}>
-                {g}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Casillas hasta curva:
-          <input
-            type="number"
-            className="ml-2 border p-1 w-20"
-            value={distance}
-            min={1}
-            onChange={(e) => setDistance(Number(e.target.value))}
-          />
-        </label>
-      </div>
-      <div className="mt-4">
-        <p>
-          Rango de tirada para marcha {gear}: {range.min}-{range.max}
-        </p>
-        <p>
-          Prob. de quedarse corto: {(prob.under * 100).toFixed(0)}%
-        </p>
-        <p>Prob. de exacto: {(prob.exact * 100).toFixed(0)}%</p>
-        <p>Prob. de pasarse: {(prob.over * 100).toFixed(0)}%</p>
-        <p className="mt-2 font-semibold">
-          Marcha sugerida: {suggestion}
-        </p>
+    <div className="max-w-xl mx-auto rounded-xl shadow-md p-4 bg-gray-900 text-amber-400">
+      <h2 className="text-2xl font-bold mb-4 text-center md:text-left">Calculadora de Movimiento</h2>
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex flex-col gap-4 flex-1">
+          <label htmlFor="gear" className="text-sm">
+            Marcha
+            <select
+              id="gear"
+              aria-label="Marcha"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={gear}
+              onChange={(e) => setGear(Number(e.target.value))}
+            >
+              {[1, 2, 3, 4, 5, 6].map((g) => (
+                <option key={g} value={g}>
+                  {g}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label htmlFor="distance" className="text-sm">
+            Casillas hasta curva
+            <input
+              id="distance"
+              aria-label="Casillas hasta curva"
+              type="number"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={distance}
+              min={1}
+              onChange={(e) => setDistance(Number(e.target.value))}
+            />
+          </label>
+        </div>
+        <div className="flex flex-col gap-2 flex-1">
+          <p>
+            Rango de tirada para marcha {gear}: {range.min}-{range.max}
+          </p>
+          <p>
+            Prob. de quedarse corto: {(prob.under * 100).toFixed(0)}%
+          </p>
+          <p>Prob. de exacto: {(prob.exact * 100).toFixed(0)}%</p>
+          <p>Prob. de pasarse: {(prob.over * 100).toFixed(0)}%</p>
+          <p className="mt-2 font-semibold">
+            Marcha sugerida: {suggestion}
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- modernize MovementCalculator with dark sporty theme
- add responsive flex layout and accessible labels

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1e7995b8832c8ccf59df0ddf4e4b