### PR TITLE
Improve UX with toast notifications and icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.0"
+    "zustand": "^4.4.0",
+    "react-hot-toast": "^2.4.1",
+    "lucide-react": "^0.271.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/src/components/tools/DamagePanel/DamagePanel.tsx
+++ b/src/components/tools/DamagePanel/DamagePanel.tsx
@@ -1,12 +1,23 @@
 import { useGameStore } from '../../../store/gameStore';
+import { Minus, Plus } from 'lucide-react';
 
 function Counter({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
   const alert = value >= 5 ? 'text-red-600' : '';
   return (
     <div className="flex items-center gap-2">
-      <span className={alert}>{label}: {value}</span>
-      <button className="bg-gray-200 px-2" onClick={() => onChange(value - 1)}>-</button>
-      <button className="bg-gray-200 px-2" onClick={() => onChange(value + 1)}>+</button>
+      <span className={`${alert} transition-colors duration-300`}>{label}: {value}</span>
+      <button
+        className="bg-gradient-to-r from-gray-200 to-gray-300 px-2 rounded hover:scale-105 transition-transform focus:outline-none"
+        onClick={() => onChange(value - 1)}
+      >
+        <Minus className="w-4 h-4" />
+      </button>
+      <button
+        className="bg-gradient-to-r from-gray-200 to-gray-300 px-2 rounded hover:scale-105 transition-transform focus:outline-none"
+        onClick={() => onChange(value + 1)}
+      >
+        <Plus className="w-4 h-4" />
+      </button>
     </div>
   );
 }

--- a/src/components/tools/DiceRoller/DiceRoller.tsx
+++ b/src/components/tools/DiceRoller/DiceRoller.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { Dice5, Play } from 'lucide-react';
 import { getGearRange, rollGear } from '../../../utils/formulaD';
 
 function DiceRoller() {
@@ -10,6 +12,7 @@ function DiceRoller() {
   const handleRoll = () => {
     const r = rollGear(gear);
     setResult(r);
+    toast.success(`Resultado: ${r}`);
   };
 
   const handleSimulate = () => {
@@ -18,6 +21,7 @@ function DiceRoller() {
       seq.push(rollGear(gear));
     }
     setSequence(seq);
+    toast(`Secuencia: ${seq.join(', ')}`);
   };
 
   const range = getGearRange(gear);
@@ -41,8 +45,11 @@ function DiceRoller() {
           </select>
         </label>
         <p>Rango: {range.min}-{range.max}</p>
-        <button className="bg-blue-500 text-white px-2 py-1" onClick={handleRoll}>
-          Tirar dado
+        <button
+          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-2 py-1 rounded hover:scale-105 transition-transform focus:outline-none flex items-center gap-1"
+          onClick={handleRoll}
+        >
+          <Dice5 className="w-4 h-4" /> Tirar dado
         </button>
         {result !== null && <p>Resultado: {result}</p>}
         <div className="mt-2">
@@ -57,10 +64,10 @@ function DiceRoller() {
             />
           </label>
           <button
-            className="bg-green-500 text-white px-2 py-1 ml-2"
+            className="bg-gradient-to-r from-green-500 to-green-600 text-white px-2 py-1 ml-2 rounded hover:scale-105 transition-transform focus:outline-none flex items-center gap-1"
             onClick={handleSimulate}
           >
-            Simular
+            <Play className="w-4 h-4" /> Simular
           </button>
         </div>
         {sequence.length > 0 && (

--- a/src/components/tools/GameLog/GameLog.tsx
+++ b/src/components/tools/GameLog/GameLog.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { useGameStore, LogEntry } from '../../../store/gameStore';
+import { toast } from 'react-hot-toast';
+import { PlusCircle, Download, Upload } from 'lucide-react';
 
 function GameLog() {
   const logs = useGameStore((s) => s.logs);
@@ -24,6 +26,7 @@ function GameLog() {
     setPlayer('');
     setRoll(0);
     setMovement(0);
+    toast.success('Entrada añadida');
   };
 
   const handleExport = () => {
@@ -36,6 +39,7 @@ function GameLog() {
     a.download = 'logs.json';
     a.click();
     URL.revokeObjectURL(url);
+    toast.success('Log exportado');
   };
 
   return (
@@ -78,14 +82,23 @@ function GameLog() {
             onChange={(e) => setMovement(Number(e.target.value))}
           />
         </label>
-        <button className="bg-blue-500 text-white px-2 py-1" onClick={handleAdd}>
-          Añadir entrada
+        <button
+          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-2 py-1 rounded hover:scale-105 transition-transform focus:outline-none flex items-center gap-1"
+          onClick={handleAdd}
+        >
+          <PlusCircle className="w-4 h-4" /> Añadir entrada
         </button>
-        <button className="bg-green-500 text-white px-2 py-1" onClick={handleExport}>
-          Exportar JSON
+        <button
+          className="bg-gradient-to-r from-green-500 to-green-600 text-white px-2 py-1 rounded hover:scale-105 transition-transform focus:outline-none flex items-center gap-1"
+          onClick={handleExport}
+        >
+          <Download className="w-4 h-4" /> Exportar JSON
         </button>
-        <button className="bg-gray-200 px-2 py-1" onClick={load}>
-          Cargar
+        <button
+          className="bg-gradient-to-r from-gray-200 to-gray-300 px-2 py-1 rounded hover:scale-105 transition-transform focus:outline-none flex items-center gap-1"
+          onClick={load}
+        >
+          <Upload className="w-4 h-4" /> Cargar
         </button>
         <div className="mt-2">
           {logs.map((l, i) => (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { Toaster } from 'react-hot-toast';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
+    <Toaster position="top-right" />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `react-hot-toast` and `lucide-react` dependencies
- integrate `<Toaster />` in main
- show toast results when rolling dice or adding/exporting logs
- update buttons with gradients, scaling and icons
- animate damage panel value color changes

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c1e8d1dfc832cbb23f139eeb19559