### PR TITLE
Add GameStatusPanel with players, turns and timer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react-dom": "^18.2.0",
     "zustand": "^4.4.0",
     "react-hot-toast": "^2.4.1",
-    "lucide-react": "^0.271.0"
+    "lucide-react": "^0.271.0",
+    "react-router-dom": "^6.23.0",
+    "framer-motion": "^10.16.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/src/GamePage.tsx
+++ b/src/GamePage.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import Layout, { ToolId } from './components/layout/Layout';
+import MovementCalculator from './components/tools/MovementCalculator/MovementCalculator';
+import DiceRoller from './components/tools/DiceRoller/DiceRoller';
+import DamagePanel from './components/tools/DamagePanel/DamagePanel';
+import CurveAssistant from './components/tools/CurveAssistant/CurveAssistant';
+import GameLog from './components/tools/GameLog/GameLog';
+import GameStatusPanel from './components/tools/GameStatusPanel/GameStatusPanel';
+
+function GamePage() {
+  const [tool, setTool] = useState<ToolId>('movement');
+
+  let content: JSX.Element;
+  switch (tool) {
+    case 'dice':
+      content = <DiceRoller />;
+      break;
+    case 'damage':
+      content = <DamagePanel />;
+      break;
+    case 'curve':
+      content = <CurveAssistant />;
+      break;
+    case 'log':
+      content = <GameLog />;
+      break;
+    case 'movement':
+    default:
+      content = <MovementCalculator />;
+  }
+
+  return (
+    <Layout current={tool} setCurrent={setTool} aside={<GameStatusPanel />}>
+      {content}
+    </Layout>
+  );
+}
+
+export default GamePage;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,6 +8,7 @@ interface LayoutProps {
   children: ReactNode;
   current: ToolId;
   setCurrent: (id: ToolId) => void;
+  aside?: ReactNode;
 }
 
 const navItems: NavItem[] = [
@@ -18,7 +19,7 @@ const navItems: NavItem[] = [
   { id: 'log', label: 'Registro' },
 ];
 
-function Layout({ children, current, setCurrent }: LayoutProps) {
+function Layout({ children, current, setCurrent, aside }: LayoutProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
@@ -37,6 +38,7 @@ function Layout({ children, current, setCurrent }: LayoutProps) {
           className="hidden md:block"
         />
         <main className="flex-1 p-4 max-w-screen-md w-full mx-auto">{children}</main>
+        {aside && <aside className="hidden lg:block w-72 p-4">{aside}</aside>}
       </div>
       <Sidebar
         nav={navItems}

--- a/src/components/tools/GameStatusPanel/GameStatusPanel.tsx
+++ b/src/components/tools/GameStatusPanel/GameStatusPanel.tsx
@@ -1,0 +1,15 @@
+import PlayerRanking from './PlayerRanking';
+import TurnCounter from './TurnCounter';
+import TurnTimer from './TurnTimer';
+
+function GameStatusPanel() {
+  return (
+    <div className="space-y-4">
+      <PlayerRanking />
+      <TurnCounter />
+      <TurnTimer />
+    </div>
+  );
+}
+
+export default GameStatusPanel;

--- a/src/components/tools/GameStatusPanel/PlayerRanking.tsx
+++ b/src/components/tools/GameStatusPanel/PlayerRanking.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useStatusStore } from '../../../store/statusStore';
+
+function PlayerRow({ name }: { name: string }) {
+  const player = useStatusStore((s) => s.players.find((p) => p.name === name)!);
+  const update = useStatusStore((s) => s.updatePlayer);
+
+  return (
+    <tr className="border-b border-gray-700">
+      <td className="p-1">{player.name}</td>
+      <td className="p-1">
+        <input
+          type="number"
+          className="w-16 bg-gray-800 rounded px-1"
+          value={player.position}
+          onChange={(e) => update(player.name, { position: Number(e.target.value) })}
+        />
+      </td>
+      <td className="p-1">
+        <input
+          type="number"
+          className="w-12 bg-gray-800 rounded px-1"
+          value={player.gear}
+          onChange={(e) => update(player.name, { gear: Number(e.target.value) })}
+        />
+      </td>
+      <td className="p-1">
+        <input
+          type="number"
+          className="w-12 bg-gray-800 rounded px-1"
+          value={player.damage}
+          onChange={(e) => update(player.name, { damage: Number(e.target.value) })}
+        />
+      </td>
+    </tr>
+  );
+}
+
+function PlayerRanking() {
+  const players = useStatusStore((s) => s.players);
+  const add = useStatusStore((s) => s.addPlayer);
+  const [name, setName] = useState('');
+
+  const sorted = [...players].sort((a, b) => a.position - b.position);
+
+  return (
+    <div className="rounded-xl bg-gray-800 text-lime-400 shadow-md p-4">
+      <h3 className="font-semibold mb-2">Clasificación</h3>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left">Jugador</th>
+            <th className="text-left">Posición</th>
+            <th className="text-left">Marcha</th>
+            <th className="text-left">Daños</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((p) => (
+            <PlayerRow key={p.name} name={p.name} />
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-2 flex gap-2">
+        <input
+          className="flex-1 bg-gray-700 rounded px-2 text-white"
+          placeholder="Nuevo jugador"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          className="btn-primary"
+          onClick={() => {
+            if (!name) return;
+            add({ name, position: 0, gear: 1, damage: 0 });
+            setName('');
+          }}
+        >
+          Añadir
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default PlayerRanking;

--- a/src/components/tools/GameStatusPanel/TurnCounter.tsx
+++ b/src/components/tools/GameStatusPanel/TurnCounter.tsx
@@ -1,0 +1,33 @@
+import { useStatusStore } from '../../../store/statusStore';
+import { Minus, Plus } from 'lucide-react';
+
+function TurnCounter() {
+  const turn = useStatusStore((s) => s.turn);
+  const inc = useStatusStore((s) => s.incTurn);
+  const dec = useStatusStore((s) => s.decTurn);
+  const start = useStatusStore((s) => s.startPlayer);
+  const setStart = useStatusStore((s) => s.setStartPlayer);
+
+  return (
+    <div className="rounded-xl bg-gray-800 text-lime-400 shadow-md p-4 flex flex-col gap-2">
+      <h3 className="font-semibold">Turno</h3>
+      <div className="flex items-center gap-2">
+        <button className="bg-gray-700 p-1 rounded" onClick={dec} aria-label="-">
+          <Minus className="w-4 h-4" />
+        </button>
+        <span className="text-xl font-bold w-8 text-center">{turn}</span>
+        <button className="bg-gray-700 p-1 rounded" onClick={inc} aria-label="+">
+          <Plus className="w-4 h-4" />
+        </button>
+      </div>
+      <input
+        className="bg-gray-700 rounded px-2 text-white"
+        placeholder="Jugador inicial"
+        value={start}
+        onChange={(e) => setStart(e.target.value)}
+      />
+    </div>
+  );
+}
+
+export default TurnCounter;

--- a/src/components/tools/GameStatusPanel/TurnTimer.tsx
+++ b/src/components/tools/GameStatusPanel/TurnTimer.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useStatusStore } from '../../../store/statusStore';
+import { Play, Pause, RotateCcw } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { toast } from 'react-hot-toast';
+
+function format(sec: number) {
+  const m = Math.floor(sec / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(sec % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+function TurnTimer() {
+  const duration = useStatusStore((s) => s.timerDuration);
+  const remaining = useStatusStore((s) => s.timerRemaining);
+  const running = useStatusStore((s) => s.timerRunning);
+  const setDuration = useStatusStore((s) => s.setTimerDuration);
+  const setRemaining = useStatusStore((s) => s.setTimerRemaining);
+  const setRunning = useStatusStore((s) => s.setTimerRunning);
+  const reset = useStatusStore((s) => s.resetTimer);
+  const [alerted, setAlerted] = useState(false);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => {
+      setRemaining((r) => r - 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [running, setRemaining]);
+
+  useEffect(() => {
+    if (remaining <= 0 && running && !alerted) {
+      setRunning(false);
+      setAlerted(true);
+      toast.error('Tiempo!');
+    }
+  }, [remaining, running, setRunning, alerted]);
+
+  const handleStart = () => {
+    setRunning(true);
+    setAlerted(false);
+  };
+
+  return (
+    <motion.div
+      animate={remaining <= 0 ? { borderColor: '#f00' } : { borderColor: '#374151' }}
+      className="rounded-xl bg-gray-800 text-lime-400 shadow-md p-4 border-2"
+    >
+      <h3 className="font-semibold mb-2">Cronómetro</h3>
+      <div className="text-3xl font-mono text-center mb-2">{format(Math.max(0, remaining))}</div>
+      <div className="flex gap-2 justify-center">
+        <button className="bg-gray-700 p-2 rounded" onClick={running ? () => setRunning(false) : handleStart}>
+          {running ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+        </button>
+        <button className="bg-gray-700 p-2 rounded" onClick={() => { reset(); setAlerted(false); }}>
+          <RotateCcw className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <input
+          type="number"
+          className="w-20 bg-gray-700 rounded px-2 text-white"
+          value={duration}
+          onChange={(e) => setDuration(Number(e.target.value))}
+        />
+        <span>segundos</span>
+      </div>
+    </motion.div>
+  );
+}
+
+export default TurnTimer;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import GamePage from './GamePage';
 import './index.css';
 import { Toaster } from 'react-hot-toast';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/game" element={<GamePage />} />
+      </Routes>
+    </BrowserRouter>
     <Toaster position="top-right" />
   </React.StrictMode>
 );

--- a/src/store/statusStore.ts
+++ b/src/store/statusStore.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface PlayerInfo {
+  name: string;
+  position: number;
+  gear: number;
+  damage: number;
+}
+
+interface StatusState {
+  players: PlayerInfo[];
+  turn: number;
+  startPlayer: string;
+  timerDuration: number;
+  timerRemaining: number;
+  timerRunning: boolean;
+  addPlayer: (p: PlayerInfo) => void;
+  updatePlayer: (name: string, data: Partial<PlayerInfo>) => void;
+  setTurn: (t: number) => void;
+  incTurn: () => void;
+  decTurn: () => void;
+  setStartPlayer: (name: string) => void;
+  setTimerDuration: (sec: number) => void;
+  setTimerRemaining: (sec: number) => void;
+  setTimerRunning: (r: boolean) => void;
+  resetTimer: () => void;
+}
+
+export const useStatusStore = create<StatusState>()(
+  persist(
+    (set, get) => ({
+      players: [],
+      turn: 1,
+      startPlayer: '',
+      timerDuration: 120,
+      timerRemaining: 120,
+      timerRunning: false,
+      addPlayer: (p) =>
+        set((state) => ({ players: [...state.players, p] })),
+      updatePlayer: (name, data) =>
+        set((state) => ({
+          players: state.players.map((pl) =>
+            pl.name === name ? { ...pl, ...data } : pl
+          ),
+        })),
+      setTurn: (t) => set({ turn: t }),
+      incTurn: () => set((s) => ({ turn: s.turn + 1 })),
+      decTurn: () => set((s) => ({ turn: Math.max(1, s.turn - 1) })),
+      setStartPlayer: (name) => set({ startPlayer: name }),
+      setTimerDuration: (sec) =>
+        set({ timerDuration: sec, timerRemaining: sec }),
+      setTimerRemaining: (sec) => set({ timerRemaining: sec }),
+      setTimerRunning: (r) => set({ timerRunning: r }),
+      resetTimer: () =>
+        set((s) => ({
+          timerRemaining: s.timerDuration,
+          timerRunning: false,
+        })),
+    }),
+    { name: 'status-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add `react-router-dom` and `framer-motion`
- extend `Layout` to optionally render an aside element
- implement a persistent store for game status with players, turn and timer data
- add `GameStatusPanel` module with `PlayerRanking`, `TurnCounter` and `TurnTimer`
- create `GamePage` route showing the panel as an aside
- hook router in `main.tsx`

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*


------
https://chatgpt.com/codex/tasks/task_e_687c25e12eac832c84c11e2ec0f4108d