### PR TITLE
Add QualifyingPanel module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import DiceRoller from './components/tools/DiceRoller/DiceRoller';
 import DamagePanel from './components/tools/DamagePanel/DamagePanel';
 import CurveAssistant from './components/tools/CurveAssistant/CurveAssistant';
 import GameLog from './components/tools/GameLog/GameLog';
+import QualifyingPanel from './components/tools/QualifyingPanel/QualifyingPanel';
 
 function App() {
   const [tool, setTool] = useState<ToolId>('movement');
@@ -19,6 +20,9 @@ function App() {
       break;
     case 'curve':
       content = <CurveAssistant />;
+      break;
+    case 'qualify':
+      content = <QualifyingPanel />;
       break;
     case 'log':
       content = <GameLog />;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState } from 'react';
 import Header, { NavItem } from './Header';
 import Sidebar from './Sidebar';
 
-export type ToolId = 'movement' | 'dice' | 'damage' | 'curve' | 'log';
+export type ToolId = 'movement' | 'dice' | 'damage' | 'curve' | 'log' | 'qualify';
 
 interface LayoutProps {
   children: ReactNode;
@@ -16,6 +16,7 @@ const navItems: NavItem[] = [
   { id: 'damage', label: 'Daños' },
   { id: 'curve', label: 'Curvas' },
   { id: 'log', label: 'Registro' },
+  { id: 'qualify', label: 'Clasificación' },
 ];
 
 function Layout({ children, current, setCurrent }: LayoutProps) {

--- a/src/components/tools/QualifyingPanel/QualifyingEntryForm.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingEntryForm.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { useQualifyingStore } from '../../../store/qualifyingStore';
+import { motion } from '../../../utils/fakeMotion';
+
+function QualifyingEntryForm() {
+  const addEntry = useQualifyingStore((s) => s.addEntry);
+  const [name, setName] = useState('');
+  const [time, setTime] = useState('');
+  const [rolls, setRolls] = useState(0);
+  const [penalty, setPenalty] = useState(0);
+
+  const handleAdd = () => {
+    if (!name || !time) {
+      toast.error('Nombre y tiempo requeridos');
+      return;
+    }
+    addEntry({ name, time, rolls, penalty });
+    toast.success('Resultado agregado');
+    setName('');
+    setTime('');
+    setRolls(0);
+    setPenalty(0);
+  };
+
+  return (
+    <motion.div layout className="card bg-gray-900 rounded-xl text-lime-300">
+      <div className="flex flex-col gap-2">
+        <label className="text-amber-400">
+          Nombre
+          <input
+            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="text-amber-400">
+          Tiempo
+          <input
+            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white"
+            placeholder="MM:SS"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </label>
+        <label className="text-amber-400">
+          Tiradas
+          <input
+            type="number"
+            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white w-20"
+            min={0}
+            value={rolls}
+            onChange={(e) => setRolls(Number(e.target.value))}
+          />
+        </label>
+        <label className="text-amber-400">
+          Penalización
+          <input
+            type="number"
+            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white w-20"
+            value={penalty}
+            onChange={(e) => setPenalty(Number(e.target.value))}
+          />
+        </label>
+        <button className="btn-primary self-start mt-2" onClick={handleAdd}>
+          Agregar resultado
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+export default QualifyingEntryForm;

--- a/src/components/tools/QualifyingPanel/QualifyingPanel.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingPanel.tsx
@@ -1,0 +1,38 @@
+import { toast } from 'react-hot-toast';
+import QualifyingEntryForm from './QualifyingEntryForm';
+import QualifyingTable from './QualifyingTable';
+import { useQualifyingStore } from '../../../store/qualifyingStore';
+import { sortEntries } from './QualifyingTable';
+
+interface QualifyingPanelProps {
+  onConfirm?: (entries: ReturnType<typeof sortEntries>) => void;
+}
+
+function QualifyingPanel({ onConfirm }: QualifyingPanelProps) {
+  const entries = useQualifyingStore((s) => s.entries);
+  const clear = useQualifyingStore((s) => s.clear);
+
+  const handleConfirm = () => {
+    const sorted = sortEntries(entries);
+    if (onConfirm) {
+      onConfirm(sorted);
+    }
+    toast.success('Clasificación confirmada');
+    clear();
+  };
+
+  return (
+    <div className="max-w-xl mx-auto bg-gray-900 rounded-xl p-4 text-lime-300">
+      <h2 className="text-2xl font-bold mb-4 text-center">Clasificación</h2>
+      <QualifyingEntryForm />
+      <QualifyingTable />
+      {entries.length > 0 && (
+        <button className="btn-primary mt-4" onClick={handleConfirm}>
+          Confirmar Clasificación
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default QualifyingPanel;

--- a/src/components/tools/QualifyingPanel/QualifyingTable.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingTable.tsx
@@ -1,0 +1,87 @@
+import { useQualifyingStore, QualifyingEntry } from '../../../store/qualifyingStore';
+import { motion } from '../../../utils/fakeMotion';
+
+function parseTime(t: string) {
+  const [m, s] = t.split(':').map(Number);
+  if (isNaN(m) || isNaN(s)) return Infinity;
+  return m * 60 + s;
+}
+
+export function sortEntries(entries: QualifyingEntry[]) {
+  return [...entries].sort((a, b) => {
+    const ta = parseTime(a.time);
+    const tb = parseTime(b.time);
+    if (ta !== tb) return ta - tb;
+    if (a.rolls !== b.rolls) return a.rolls - b.rolls;
+    return a.penalty - b.penalty;
+  });
+}
+
+function QualifyingTable() {
+  const entries = useQualifyingStore((s) => s.entries);
+  const update = useQualifyingStore((s) => s.updateEntry);
+  const remove = useQualifyingStore((s) => s.removeEntry);
+
+  const sorted = sortEntries(entries);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left">
+        <thead className="text-lime-300">
+          <tr>
+            <th className="p-2">Pos</th>
+            <th className="p-2">Nombre</th>
+            <th className="p-2">Tiempo</th>
+            <th className="p-2">Tiradas</th>
+            <th className="p-2">Penalización</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((e, index) => (
+            <motion.tr key={e.id} layout className="text-amber-400">
+              <td className="p-2">{index + 1}</td>
+              <td className="p-2">
+                <input
+                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white"
+                  value={e.name}
+                  onChange={(ev) => update(e.id, { name: ev.target.value })}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
+                  value={e.time}
+                  onChange={(ev) => update(e.id, { time: ev.target.value })}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  type="number"
+                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
+                  value={e.rolls}
+                  onChange={(ev) => update(e.id, { rolls: Number(ev.target.value) })}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  type="number"
+                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
+                  value={e.penalty}
+                  onChange={(ev) => update(e.id, { penalty: Number(ev.target.value) })}
+                />
+              </td>
+              <td className="p-2">
+                <button className="text-red-500" onClick={() => remove(e.id)}>
+                  X
+                </button>
+              </td>
+            </motion.tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default QualifyingTable;

--- a/src/store/qualifyingStore.ts
+++ b/src/store/qualifyingStore.ts
@@ -1,0 +1,40 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface QualifyingEntry {
+  id: string;
+  name: string;
+  time: string;
+  rolls: number;
+  penalty: number;
+}
+
+interface QualifyingState {
+  entries: QualifyingEntry[];
+  addEntry: (e: Omit<QualifyingEntry, 'id'>) => void;
+  updateEntry: (id: string, e: Partial<QualifyingEntry>) => void;
+  removeEntry: (id: string) => void;
+  clear: () => void;
+}
+
+export const useQualifyingStore = create<QualifyingState>(
+  persist(
+    (set) => ({
+      entries: [],
+      addEntry: (e) =>
+        set((state) => ({
+          entries: [...state.entries, { ...e, id: `${Date.now()}-${Math.random()}` }],
+        })),
+      updateEntry: (id, e) =>
+        set((state) => ({
+          entries: state.entries.map((en) => (en.id === id ? { ...en, ...e } : en)),
+        })),
+      removeEntry: (id) =>
+        set((state) => ({ entries: state.entries.filter((en) => en.id !== id) })),
+      clear: () => set({ entries: [] }),
+    }),
+    {
+      name: 'qualifying',
+    },
+  ),
+);

--- a/src/utils/fakeMotion.tsx
+++ b/src/utils/fakeMotion.tsx
@@ -1,0 +1,12 @@
+import { forwardRef } from 'react';
+
+function withAnimation<T extends HTMLElement>(Tag: React.ElementType) {
+  return forwardRef<T, React.HTMLAttributes<T>>(({ className = '', ...rest }, ref) => (
+    <Tag ref={ref} className={`${className} animate-bounce-in`} {...rest} />
+  ));
+}
+
+export const motion = {
+  div: withAnimation<HTMLDivElement>('div'),
+  tr: withAnimation<HTMLTableRowElement>('tr'),
+};


### PR DESCRIPTION
## Summary
- create QualifyingPanel with entry form and results table
- manage qualifying data with zustand store
- provide simple motion helpers and animate rows
- extend navigation and tool switcher

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c2641b0f8832c8b580f2ebe269ce3