### PR TITLE
Add interactive timers and counters to Qualifying panel

### DIFF
--- a/src/components/tools/QualifyingPanel/QualifyingEntryForm.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingEntryForm.tsx
@@ -6,21 +6,16 @@ import { motion } from '../../../utils/fakeMotion';
 function QualifyingEntryForm() {
   const addEntry = useQualifyingStore((s) => s.addEntry);
   const [name, setName] = useState('');
-  const [time, setTime] = useState('');
-  const [rolls, setRolls] = useState(0);
-  const [penalty, setPenalty] = useState(0);
+  const [time] = useState('00:00');
 
   const handleAdd = () => {
-    if (!name || !time) {
-      toast.error('Nombre y tiempo requeridos');
+    if (!name) {
+      toast.error('Nombre requerido');
       return;
     }
-    addEntry({ name, time, rolls, penalty });
+    addEntry({ name, time, rolls: 0, penalty: 0 });
     toast.success('Resultado agregado');
     setName('');
-    setTime('');
-    setRolls(0);
-    setPenalty(0);
   };
 
   return (
@@ -32,34 +27,6 @@ function QualifyingEntryForm() {
             className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white"
             value={name}
             onChange={(e) => setName(e.target.value)}
-          />
-        </label>
-        <label className="text-amber-400">
-          Tiempo
-          <input
-            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white"
-            placeholder="MM:SS"
-            value={time}
-            onChange={(e) => setTime(e.target.value)}
-          />
-        </label>
-        <label className="text-amber-400">
-          Tiradas
-          <input
-            type="number"
-            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white w-20"
-            min={0}
-            value={rolls}
-            onChange={(e) => setRolls(Number(e.target.value))}
-          />
-        </label>
-        <label className="text-amber-400">
-          Penalización
-          <input
-            type="number"
-            className="ml-2 rounded bg-gray-800 border border-gray-700 p-1 text-white w-20"
-            value={penalty}
-            onChange={(e) => setPenalty(Number(e.target.value))}
           />
         </label>
         <button className="btn-primary self-start mt-2" onClick={handleAdd}>

--- a/src/components/tools/QualifyingPanel/QualifyingRow.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingRow.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from 'react';
+import { Play, Pause, RotateCcw } from 'lucide-react';
+import { motion } from '../../../utils/fakeMotion';
+import { QualifyingEntry, useQualifyingStore } from '../../../store/qualifyingStore';
+import useTimer from '../../../hooks/useTimer';
+import { parseTime, formatTime } from '../../../utils/time';
+
+interface Props {
+  entry: QualifyingEntry;
+  index: number;
+}
+
+function QualifyingRow({ entry, index }: Props) {
+  const update = useQualifyingStore((s) => s.updateEntry);
+  const remove = useQualifyingStore((s) => s.removeEntry);
+  const { seconds, running, start, stop, reset, setSeconds } = useTimer(parseTime(entry.time));
+
+  useEffect(() => {
+    update(entry.id, { time: formatTime(seconds) });
+  }, [seconds, entry.id, update]);
+
+  const incRolls = (delta: number) => {
+    update(entry.id, { rolls: Math.max(0, entry.rolls + delta) });
+  };
+
+  const incPenalty = (delta: number) => {
+    update(entry.id, { penalty: Math.max(0, entry.penalty + delta) });
+  };
+
+  const handleResetTimer = () => {
+    reset();
+    setSeconds(0);
+  };
+
+  return (
+    <motion.tr layout className="text-amber-400">
+      <td className="p-2">{index + 1}</td>
+      <td className="p-2">
+        <input
+          className="bg-gray-800 border border-gray-700 rounded p-1 text-white"
+          value={entry.name}
+          onChange={(e) => update(entry.id, { name: e.target.value })}
+        />
+      </td>
+      <td className="p-2">
+        <div className="flex items-center gap-1">
+          <span className="w-16 text-center font-mono">{formatTime(seconds)}</span>
+          <button
+            className="bg-gray-700 rounded-full p-1 hover:bg-lime-600"
+            onClick={running ? stop : start}
+            aria-label="start-stop"
+          >
+            {running ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+          </button>
+          <button
+            className="bg-gray-700 rounded-full p-1 hover:bg-lime-600"
+            onClick={handleResetTimer}
+            aria-label="reset"
+          >
+            <RotateCcw className="w-4 h-4" />
+          </button>
+        </div>
+      </td>
+      <td className="p-2">
+        <div className="flex items-center gap-1">
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xl"
+            onClick={() => incRolls(-1)}
+          >
+            –
+          </button>
+          <span className="w-6 text-center">{entry.rolls}</span>
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xl"
+            onClick={() => incRolls(1)}
+          >
+            +
+          </button>
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xs"
+            onClick={() => update(entry.id, { rolls: 0 })}
+          >
+            Reset
+          </button>
+        </div>
+      </td>
+      <td className="p-2">
+        <div className="flex items-center gap-1">
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xl"
+            onClick={() => incPenalty(-1)}
+          >
+            –
+          </button>
+          <span className="w-6 text-center">{entry.penalty}</span>
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xl"
+            onClick={() => incPenalty(1)}
+          >
+            +
+          </button>
+          <button
+            className="bg-gray-700 rounded-full px-2 hover:bg-lime-600 text-xs"
+            onClick={() => update(entry.id, { penalty: 0 })}
+          >
+            Reset
+          </button>
+        </div>
+      </td>
+      <td className="p-2">
+        <button className="text-red-500" onClick={() => remove(entry.id)}>
+          X
+        </button>
+      </td>
+    </motion.tr>
+  );
+}
+
+export default QualifyingRow;

--- a/src/components/tools/QualifyingPanel/QualifyingTable.tsx
+++ b/src/components/tools/QualifyingPanel/QualifyingTable.tsx
@@ -1,11 +1,6 @@
 import { useQualifyingStore, QualifyingEntry } from '../../../store/qualifyingStore';
-import { motion } from '../../../utils/fakeMotion';
-
-function parseTime(t: string) {
-  const [m, s] = t.split(':').map(Number);
-  if (isNaN(m) || isNaN(s)) return Infinity;
-  return m * 60 + s;
-}
+import QualifyingRow from './QualifyingRow';
+import { parseTime } from '../../../utils/time';
 
 export function sortEntries(entries: QualifyingEntry[]) {
   return [...entries].sort((a, b) => {
@@ -19,9 +14,6 @@ export function sortEntries(entries: QualifyingEntry[]) {
 
 function QualifyingTable() {
   const entries = useQualifyingStore((s) => s.entries);
-  const update = useQualifyingStore((s) => s.updateEntry);
-  const remove = useQualifyingStore((s) => s.removeEntry);
-
   const sorted = sortEntries(entries);
 
   return (
@@ -39,44 +31,7 @@ function QualifyingTable() {
         </thead>
         <tbody>
           {sorted.map((e, index) => (
-            <motion.tr key={e.id} layout className="text-amber-400">
-              <td className="p-2">{index + 1}</td>
-              <td className="p-2">
-                <input
-                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white"
-                  value={e.name}
-                  onChange={(ev) => update(e.id, { name: ev.target.value })}
-                />
-              </td>
-              <td className="p-2">
-                <input
-                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
-                  value={e.time}
-                  onChange={(ev) => update(e.id, { time: ev.target.value })}
-                />
-              </td>
-              <td className="p-2">
-                <input
-                  type="number"
-                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
-                  value={e.rolls}
-                  onChange={(ev) => update(e.id, { rolls: Number(ev.target.value) })}
-                />
-              </td>
-              <td className="p-2">
-                <input
-                  type="number"
-                  className="bg-gray-800 border border-gray-700 rounded p-1 text-white w-20"
-                  value={e.penalty}
-                  onChange={(ev) => update(e.id, { penalty: Number(ev.target.value) })}
-                />
-              </td>
-              <td className="p-2">
-                <button className="text-red-500" onClick={() => remove(e.id)}>
-                  X
-                </button>
-              </td>
-            </motion.tr>
+            <QualifyingRow key={e.id} entry={e} index={index} />
           ))}
         </tbody>
       </table>

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState, useCallback } from 'react';
+
+export default function useTimer(initial: number = 0) {
+  const [seconds, setSeconds] = useState(initial);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => {
+      setSeconds((s) => s + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [running]);
+
+  const start = useCallback(() => setRunning(true), []);
+  const stop = useCallback(() => setRunning(false), []);
+  const reset = useCallback(() => {
+    setSeconds(0);
+    setRunning(false);
+  }, []);
+
+  return { seconds, running, start, stop, reset, setSeconds };
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,15 @@
+export function parseTime(t: string) {
+  const [m, s] = t.split(':').map(Number);
+  if (isNaN(m) || isNaN(s)) return 0;
+  return m * 60 + s;
+}
+
+export function formatTime(sec: number) {
+  const m = Math.floor(sec / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(sec % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${m}:${s}`;
+}


### PR DESCRIPTION
## Summary
- create a small `useTimer` hook
- add helpers to parse/format lap times
- add `QualifyingRow` component with timer, roll and penalty controls
- simplify entry form to only request player name
- update table to render `QualifyingRow`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c2c2e8124832c996f84a63edb728e