### PR TITLE
Add lane-aware movement calculator

### DIFF
--- a/src/components/tools/MovementCalculator/MovementCalculator.tsx
+++ b/src/components/tools/MovementCalculator/MovementCalculator.tsx
@@ -1,17 +1,56 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   getGearRange,
-  probabilityToReach,
-  suggestGear,
+  probabilityToHandleCurve,
+  suggestGearForCurve,
+  Lane,
+  CurveDirection,
+  Curve,
 } from '../../../utils/formulaD';
 
 function MovementCalculator() {
   const [gear, setGear] = useState(1);
   const [distance, setDistance] = useState(1);
+  const [currentLane, setCurrentLane] = useState<Lane>('medio');
+  const [targetLane, setTargetLane] = useState<Lane>('medio');
+  const [direction, setDirection] = useState<CurveDirection>('derecha');
+  const [turns, setTurns] = useState(2);
+
+  useEffect(() => {
+    const defaults: Record<Lane, number> = {
+      exterior: 1,
+      medio: 2,
+      interior: 3,
+    };
+    setTurns(defaults[targetLane]);
+  }, [targetLane]);
+
+  const curve: Curve = {
+    lane: targetLane,
+    direction,
+    requiredTurns: turns,
+  };
 
   const range = getGearRange(gear);
-  const prob = probabilityToReach(gear, distance);
-  const suggestion = suggestGear(distance);
+  const prob = probabilityToHandleCurve(gear, distance, curve);
+  const suggestion = suggestGearForCurve(distance, curve);
+
+  const laneIndex: Record<Lane, number> = {
+    interior: 0,
+    medio: 1,
+    exterior: 2,
+  };
+
+  let warning: string | null = null;
+  const diff = Math.abs(laneIndex[currentLane] - laneIndex[targetLane]);
+  if (diff > 1) {
+    warning = 'Cambio de carril ilegal (más de uno)';
+  } else if (
+    (direction === 'derecha' && laneIndex[targetLane] > laneIndex[currentLane]) ||
+    (direction === 'izquierda' && laneIndex[targetLane] < laneIndex[currentLane])
+  ) {
+    warning = 'Dirección de cambio de carril contraria a la curva';
+  }
 
   return (
     <div className="max-w-xl mx-auto rounded-xl shadow-md p-4 bg-gray-900 text-amber-400">
@@ -46,19 +85,66 @@ function MovementCalculator() {
               onChange={(e) => setDistance(Number(e.target.value))}
             />
           </label>
+          <label htmlFor="currentLane" className="text-sm">
+            Carril actual
+            <select
+              id="currentLane"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={currentLane}
+              onChange={(e) => setCurrentLane(e.target.value as Lane)}
+            >
+              <option value="exterior" className="text-red-400">Exterior</option>
+              <option value="medio" className="text-yellow-400">Medio</option>
+              <option value="interior" className="text-green-400">Interior</option>
+            </select>
+          </label>
+          <label htmlFor="targetLane" className="text-sm">
+            Carril al entrar
+            <select
+              id="targetLane"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={targetLane}
+              onChange={(e) => setTargetLane(e.target.value as Lane)}
+            >
+              <option value="exterior" className="text-red-400">Exterior</option>
+              <option value="medio" className="text-yellow-400">Medio</option>
+              <option value="interior" className="text-green-400">Interior</option>
+            </select>
+          </label>
+          <label htmlFor="direction" className="text-sm">
+            Dirección de la curva
+            <select
+              id="direction"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={direction}
+              onChange={(e) => setDirection(e.target.value as CurveDirection)}
+            >
+              <option value="derecha">Derecha</option>
+              <option value="izquierda">Izquierda</option>
+            </select>
+          </label>
+          <label htmlFor="turns" className="text-sm">
+            Turnos mínimos en el carril
+            <input
+              id="turns"
+              type="number"
+              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              value={turns}
+              min={1}
+              onChange={(e) => setTurns(Number(e.target.value))}
+            />
+          </label>
         </div>
         <div className="flex flex-col gap-2 flex-1">
           <p>
             Rango de tirada para marcha {gear}: {range.min}-{range.max}
           </p>
-          <p>
-            Prob. de quedarse corto: {(prob.under * 100).toFixed(0)}%
-          </p>
-          <p>Prob. de exacto: {(prob.exact * 100).toFixed(0)}%</p>
-          <p>Prob. de pasarse: {(prob.over * 100).toFixed(0)}%</p>
-          <p className="mt-2 font-semibold">
-            Marcha sugerida: {suggestion}
-          </p>
+          <p>Longitud de la curva: {prob.length} casillas</p>
+          <p>Prob. de quedarse antes: {(prob.before * 100).toFixed(0)}%</p>
+          <p>Prob. de entrar legalmente: {(prob.inCurve * 100).toFixed(0)}%</p>
+          <p>Prob. de pasarse: {(prob.overshoot * 100).toFixed(0)}%</p>
+          <p className="mt-2 font-semibold">Marcha sugerida: {suggestion}</p>
+          {warning && <p className="text-red-400">{warning}</p>}
         </div>
       </div>
     </div>

--- a/src/utils/formulaD.ts
+++ b/src/utils/formulaD.ts
@@ -45,3 +45,41 @@ export function rollGear(gear: number) {
   return dice[index];
 }
 
+export type Lane = 'interior' | 'medio' | 'exterior';
+export type CurveDirection = 'izquierda' | 'derecha';
+
+export interface Curve {
+  lane: Lane;
+  direction: CurveDirection;
+  requiredTurns: number;
+}
+
+const laneFactor: Record<Lane, number> = {
+  interior: 5,
+  medio: 6,
+  exterior: 7,
+};
+
+export function getCurveLength(curve: Curve) {
+  return laneFactor[curve.lane] * curve.requiredTurns;
+}
+
+export function probabilityToHandleCurve(
+  gear: number,
+  distance: number,
+  curve: Curve,
+) {
+  const { dice } = gears[gear];
+  const total = dice.length;
+  const length = getCurveLength(curve);
+  const before = dice.filter((d) => d < distance).length / total;
+  const inCurve =
+    dice.filter((d) => d >= distance && d <= distance + length).length / total;
+  const overshoot = dice.filter((d) => d > distance + length).length / total;
+  return { before, inCurve, overshoot, length };
+}
+
+export function suggestGearForCurve(distance: number, curve: Curve) {
+  return suggestGear(distance + getCurveLength(curve));
+}
+


### PR DESCRIPTION
## Summary
- add lane and curve logic utilities
- extend MovementCalculator with lane, direction and curve options

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c686b6268832caf5bb52059747f59