### PR TITLE
Apply dopamine-themed redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Formula D Utils</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Rajdhani:wght@400;700&display=swap" rel="stylesheet" />
   </head>
   <body class="font-sans">
     <div id="root"></div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,14 +14,14 @@ interface HeaderProps {
 
 function Header({ nav, current, onSelect, onMenu }: HeaderProps) {
   return (
-    <header className="bg-gray-800 text-white px-4 py-3 flex items-center justify-between">
-      <h1 className="text-lg font-semibold">Formula D Utils</h1>
+    <header className="bg-graphite border-b border-electricBlue shadow-neon text-electricBlue px-4 py-3 flex items-center justify-between">
+      <h1 className="font-display text-neonPink text-xl">Formula D Utils</h1>
       <nav className="hidden md:flex gap-4">
         {nav.map((item) => (
           <button
             key={item.id}
-            className={`pb-1 border-b-2 ${
-              current === item.id ? 'border-white' : 'border-transparent'
+            className={`pb-1 border-b-2 transition-colors ${
+              current === item.id ? 'border-neonPink text-neonPink' : 'border-transparent'
             }`}
             onClick={() => onSelect(item.id)}
           >
@@ -29,7 +29,7 @@ function Header({ nav, current, onSelect, onMenu }: HeaderProps) {
           </button>
         ))}
       </nav>
-      <button className="md:hidden" onClick={onMenu} aria-label="Menu">
+      <button className="md:hidden text-neonPink" onClick={onMenu} aria-label="Menu">
         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
         </svg>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -24,7 +24,7 @@ function Layout({ children, current, setCurrent, aside }: LayoutProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <div className="min-h-screen flex flex-col font-sans text-gray-800">
+    <div className="min-h-screen flex flex-col font-sans bg-carbon text-electricBlue">
       <Header
         nav={navItems}
         current={current}
@@ -38,7 +38,7 @@ function Layout({ children, current, setCurrent, aside }: LayoutProps) {
           onSelect={(id) => setCurrent(id as ToolId)}
           className="hidden md:block"
         />
-        <main className="flex-1 p-4 max-w-screen-md w-full mx-auto">{children}</main>
+        <main className="flex-1 p-6 max-w-screen-md w-full mx-auto grid gap-6">{children}</main>
         {aside && <aside className="hidden lg:block w-72 p-4">{aside}</aside>}
       </div>
       <Sidebar

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,15 +13,15 @@ interface SidebarProps {
 
 function Sidebar({ nav, current, onSelect, open = false, onClose, mobile = false, className = '' }: SidebarProps) {
   const base = mobile
-    ? `fixed inset-y-0 left-0 w-64 bg-white shadow transform transition-transform z-20 ${open ? 'translate-x-0' : '-translate-x-full'}`
-    : `w-48 bg-gray-100 p-4 ${className}`;
+    ? `fixed inset-y-0 left-0 w-64 bg-graphite/90 backdrop-blur-lg transform transition-transform z-20 ${open ? 'translate-x-0' : '-translate-x-full'}`
+    : `w-48 bg-graphite/70 backdrop-blur-lg text-electricBlue p-4 border-r border-electricBlue ${className}`;
 
   const content = (
     <div className="h-full flex flex-col gap-2 p-4">
       {nav.map((item) => (
         <button
           key={item.id}
-          className={`text-left ${current === item.id ? 'font-semibold' : ''}`}
+          className={`text-left rounded px-2 py-1 transition-colors ${current === item.id ? 'bg-electricBlue text-graphite font-semibold' : 'hover:text-neonPink'}`}
           onClick={() => onSelect(item.id)}
         >
           {item.label}

--- a/src/components/tools/MovementCalculator/MovementCalculator.tsx
+++ b/src/components/tools/MovementCalculator/MovementCalculator.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 import {
   getGearRange,
   probabilityToHandleCurve,
@@ -53,8 +54,13 @@ function MovementCalculator() {
   }
 
   return (
-    <div className="max-w-xl mx-auto rounded-xl shadow-md p-4 bg-gray-900 text-amber-400">
-      <h2 className="text-2xl font-bold mb-4 text-center md:text-left">Calculadora de Movimiento</h2>
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="card-glow max-w-xl mx-auto text-acidYellow"
+    >
+      <h2 className="text-2xl font-display font-bold mb-4 text-center md:text-left text-electricBlue">Calculadora de Movimiento</h2>
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex flex-col gap-4 flex-1">
           <label htmlFor="gear" className="text-sm">
@@ -62,7 +68,7 @@ function MovementCalculator() {
             <select
               id="gear"
               aria-label="Marcha"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={gear}
               onChange={(e) => setGear(Number(e.target.value))}
             >
@@ -79,7 +85,7 @@ function MovementCalculator() {
               id="distance"
               aria-label="Casillas hasta curva"
               type="number"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={distance}
               min={1}
               onChange={(e) => setDistance(Number(e.target.value))}
@@ -89,7 +95,7 @@ function MovementCalculator() {
             Carril actual
             <select
               id="currentLane"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={currentLane}
               onChange={(e) => setCurrentLane(e.target.value as Lane)}
             >
@@ -102,7 +108,7 @@ function MovementCalculator() {
             Carril al entrar
             <select
               id="targetLane"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={targetLane}
               onChange={(e) => setTargetLane(e.target.value as Lane)}
             >
@@ -115,7 +121,7 @@ function MovementCalculator() {
             Dirección de la curva
             <select
               id="direction"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={direction}
               onChange={(e) => setDirection(e.target.value as CurveDirection)}
             >
@@ -128,7 +134,7 @@ function MovementCalculator() {
             <input
               id="turns"
               type="number"
-              className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+              className="mt-1 w-full rounded-xl bg-carbon border border-electricBlue p-2 text-electricBlue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neonPink"
               value={turns}
               min={1}
               onChange={(e) => setTurns(Number(e.target.value))}
@@ -143,11 +149,11 @@ function MovementCalculator() {
           <p>Prob. de quedarse antes: {(prob.before * 100).toFixed(0)}%</p>
           <p>Prob. de entrar legalmente: {(prob.inCurve * 100).toFixed(0)}%</p>
           <p>Prob. de pasarse: {(prob.overshoot * 100).toFixed(0)}%</p>
-          <p className="mt-2 font-semibold">Marcha sugerida: {suggestion}</p>
-          {warning && <p className="text-red-400">{warning}</p>}
+          <p className="mt-2 font-semibold text-electricBlue">Marcha sugerida: {suggestion}</p>
+          {warning && <p className="text-intenseRed">{warning}</p>}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,16 @@
 
 @layer base {
   body {
-    @apply font-sans bg-background text-white;
+    @apply font-sans bg-carbon text-white;
+  }
+}
+
+@layer components {
+  .btn-primary-dopamine {
+    @apply bg-neonPink text-graphite font-bold py-2 px-4 rounded-xl transition-colors hover:bg-electricBlue;
+  }
+
+  .card-glow {
+    @apply rounded-2xl p-4 bg-graphite bg-opacity-60 backdrop-blur-md shadow-neon border border-electricBlue;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ const colors = require('tailwindcss/colors');
 const plugin = require('tailwindcss/plugin');
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{ts,tsx}',
@@ -9,15 +10,17 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        background: colors.gray['900'],
-        primary: colors.amber,
-        accent: {
-          orange: colors.orange,
-          lime: colors.lime,
-        },
+        carbon: '#0F0F0F',
+        graphite: '#1C1C1E',
+        neonPink: '#FF4FCB',
+        electricBlue: '#3B9CFF',
+        intenseRed: '#FF2E2E',
+        brightGreen: '#0AFFA0',
+        acidYellow: '#FFDC00',
       },
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+        sans: ['Rajdhani', 'ui-sans-serif', 'system-ui'],
+        display: ['Orbitron', 'Rajdhani', 'ui-sans-serif'],
       },
       keyframes: {
         'bounce-in': {
@@ -29,26 +32,29 @@ module.exports = {
       animation: {
         'bounce-in': 'bounce-in 0.5s ease-out both',
       },
+      boxShadow: {
+        neon: '0 0 10px 0 rgba(255, 79, 203, 0.7)',
+      },
     },
   },
   plugins: [
     plugin(function ({ addComponents, theme }) {
       addComponents({
         '.card': {
-          backgroundColor: theme('colors.background'),
+          backgroundColor: theme('colors.graphite'),
           color: theme('colors.white'),
           padding: theme('spacing.4'),
           borderRadius: theme('borderRadius.lg'),
           boxShadow: theme('boxShadow.md'),
         },
         '.btn-primary': {
-          backgroundColor: theme('colors.primary.500'),
-          color: theme('colors.white'),
+          backgroundColor: theme('colors.neonPink'),
+          color: theme('colors.graphite'),
           padding: `${theme('spacing.2')} ${theme('spacing.4')}`,
           borderRadius: theme('borderRadius.md'),
           fontWeight: theme('fontWeight.semibold'),
           '&:hover': {
-            backgroundColor: theme('colors.primary.600'),
+            backgroundColor: theme('colors.electricBlue'),
           },
         },
       });


### PR DESCRIPTION
## Summary
- add dopamine color palette and fonts to Tailwind theme
- create `.btn-primary-dopamine` and `.card-glow` component classes
- load Orbitron and Rajdhani fonts
- restyle layout and navigation
- update MovementCalculator with new look and framer-motion animation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c98132508832cb0809692bb028ac2